### PR TITLE
DEV-11258 Fix double /v3 on uri paths

### DIFF
--- a/client_impl.go
+++ b/client_impl.go
@@ -18,7 +18,7 @@ import (
 //   - signatureRequestId The id of the SignatureRequest to retrieve.
 //   - fileType Set to "pdf" for a single merged document or "zip" for a collection of individual documents.
 func (c *Client) DownloadFiles(ctx context.Context, signatureRequestID, fileType string) ([]byte, error) {
-	furl := fmt.Sprintf("%s/v3/signature_request/files/%s", c.baseURL, url.PathEscape(signatureRequestID))
+	furl := fmt.Sprintf("%s/signature_request/files/%s", c.baseURL, url.PathEscape(signatureRequestID))
 	if fileType != "" {
 		furl += "?file_type=" + url.QueryEscape(fileType)
 	}
@@ -37,7 +37,7 @@ func (c *Client) DownloadFiles(ctx context.Context, signatureRequestID, fileType
 // Note that embedded signature requests can only be signed in embedded iFrames whereas normal signature requests
 // can only be signed on Dropbox Sign.
 func (c *Client) CreateEmbeddedWithTemplate(ctx context.Context, r model.CreateEmbeddedWithTemplateRequest) (*model.SignatureRequestGetResponse, error) {
-	furl := fmt.Sprintf("%s/v3/signature_request/create_embedded_with_template", c.baseURL)
+	furl := fmt.Sprintf("%s/signature_request/create_embedded_with_template", c.baseURL)
 	req, err := c.newJSONRequest(ctx, http.MethodPost, furl, r)
 	if err != nil {
 		return nil, err
@@ -51,7 +51,7 @@ func (c *Client) CreateEmbeddedWithTemplate(ctx context.Context, r model.CreateE
 // Parameters:
 //   - signatureId The id of the signature to get a signature url for.
 func (c *Client) GetEmbeddedSignURL(ctx context.Context, signatureID string) (*model.EmbeddedSignUrlResponse, error) {
-	furl := fmt.Sprintf("%s/v3/embedded/sign_url/%s", c.baseURL, url.PathEscape(signatureID))
+	furl := fmt.Sprintf("%s/embedded/sign_url/%s", c.baseURL, url.PathEscape(signatureID))
 	req, err := c.newJSONRequest(ctx, http.MethodPost, furl, nil)
 	if err != nil {
 		return nil, err

--- a/client_test.go
+++ b/client_test.go
@@ -44,7 +44,7 @@ func TestClient(t *testing.T) {
 
 func setupMockAPIServer() *httptest.Server {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/v3/signature_request/create_embedded_with_template", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/signature_request/create_embedded_with_template", func(w http.ResponseWriter, r *http.Request) {
 		http.ServeFile(w, r, "testdata/create_embedded_with_template.resp.json")
 	})
 	return httptest.NewServer(mux)


### PR DESCRIPTION
# Description

The /v3 should either be in the base url or the endpoint paths, not both. I chose to keep it in baseurl because that is how the Hellosign swagger file does it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)